### PR TITLE
DOC: Add repo description and link scipy.datasets docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # dataset-ecg
+
+This repo serves the data files for the
+[scipy.datasets.electrocardiogram](https://scipy.github.io/devdocs/reference/dataset/electrocardiogram.html)
+(visit for details on dataset) method in 
+the [scipy.datasets](https://scipy.github.io/devdocs/reference/datasets.html)
+submodule.
+
+The usage, retrieval and caching of data files is explained in
+[Usage of Datasets](https://scipy.github.io/devdocs/reference/datasets.html#usage-of-datasets).


### PR DESCRIPTION
Add a basic description to the `dataset-ecg` repo as requested in https://github.com/scipy/scipy/pull/15607#issuecomment-1183617500.